### PR TITLE
Remove sending page views to mckerlie.com tracking

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,17 +89,4 @@ const socialImageURL = new URL(
   <body>
     <slot />
   </body>
-  <script>
-      // @ts-nocheck
-      (function () {
-          window.counterscale = {
-              q: [["set", "siteId", "mckerlie-com"], ["trackPageview"]],
-          };
-      })();
-  </script>
-  <script
-      id="counterscale-script"
-      src="https://counterscale.adammckerlie.workers.dev/tracker.js"
-      defer
-  ></script>
 </html>


### PR DESCRIPTION
Because the code was copied directly you're currently sending traffic information to my personal counterscale instance. 